### PR TITLE
Use entity_label instead of referencing $term->name directly

### DIFF
--- a/textformatter.module
+++ b/textformatter.module
@@ -561,7 +561,7 @@ function textformatter_taxonomy_field_create_list($entity_type, $entity, $field,
       continue;
     }
     // Use the item name if autocreating, as there won't be a term object yet.
-    $term_name = ($item['tid'] === 'autocreate') ? check_plain($item['name']) : $terms[$item['tid']]->name;
+    $term_name = ($item['tid'] === 'autocreate') ? check_plain($item['name']) : entity_label('taxonomy_term', $terms[$item['tid']]);
 
     // Check if we should display as term links or not.
     if ($settings['textformatter_term_plain'] || ($item['tid'] === 'autocreate')) {


### PR DESCRIPTION
This commit swaps out entity_label for referencing $term->name directly to fix translation issues.

Fixes #12